### PR TITLE
refactoring: Make constructor with less parameters

### DIFF
--- a/PixyViSy.h
+++ b/PixyViSy.h
@@ -12,9 +12,7 @@
 class PixyViSy
 {
     public:
-        PixyViSy(uint16_t pixel_Fx, uint16_t pixel_Fy, uint8_t _goal_sig,
-            uint8_t _goal_height, uint16_t _min_goal_size, uint8_t _ball_size,
-            uint8_t _ball_sig, uint16_t _min_ball_size, uint8_t flag);
+        PixyViSy(uint16_t pixel_Fx, uint16_t pixel_Fy, uint8_t flag);
         void update(void);
 
         uint16_t getGoalDist(void) { return goal_dist; }
@@ -32,12 +30,12 @@ class PixyViSy
             if (pixel_Fy != 0) Fyp = pixel_Fy; }
         void setPixelFx(uint16_t pixel_Fx) {
             if (pixel_Fx != 0) Fxp = pixel_Fx; }
-        void setMinGoalSize(uint16_t _min_goal_size) {
-            min_goal_size = _min_goal_size; }
+        void setMinGoalArea(uint16_t _min_goal_area) {
+            min_goal_area = _min_goal_area; }
         void setBallSize(uint8_t _ball_size) { ball_size = _ball_size; }
         void setBallSig(uint8_t _ball_sig) { ball_sig = _ball_sig; }
-        void setMinBallSize(uint16_t _min_ball_size)
-            { min_ball_size = _min_ball_size; }
+        void setMinBallArea(uint16_t _min_ball_area)
+            { min_ball_area = _min_ball_area; }
         void setFlag(uint8_t flag) { process_flag = flag; }
 
         void printParams();
@@ -62,10 +60,10 @@ class PixyViSy
         uint8_t process_flag;
         uint8_t goal_sig;
         uint8_t goal_height;
-        uint8_t ball_size;
-        uint16_t min_goal_size;
+        uint16_t min_goal_area;
         uint8_t ball_sig;
-        uint16_t min_ball_size;
+        uint8_t ball_size;
+        uint16_t min_ball_area;
 
         uint16_t blocks_count;
         uint8_t goal_left_pixels;

--- a/examples/Basic_use/Basic_use.ino
+++ b/examples/Basic_use/Basic_use.ino
@@ -10,16 +10,9 @@
 #define GOAL_SIG 1
 #define BALL_SIG 2
 
-#define GOAL_HEIGHT 10
-#define BALL_DIAMETER 7
+#define MIN_GOAL_AREA 100
 
-#define MIN_GOAL_SIZE 100
-#define MIN_BALL_SIZE 0
-
-PixyViSy pixyViSy(FOC_LEN_X, FOC_LEN_Y,
-                  GOAL_SIG, GOAL_HEIGHT, MIN_GOAL_SIZE,
-                  BALL_DIAMETER, BALL_SIG, MIN_BALL_SIZE,
-                  PIXYVISY_GOAL | PIXYVISY_BALL);
+PixyViSy pixyViSy(FOC_LEN_X, FOC_LEN_Y, PIXYVISY_GOAL | PIXYVISY_BALL);
 uint16_t goal_distance, ball_distance;
 int8_t ball_angle;
 char action;
@@ -29,7 +22,12 @@ uint16_t min_time = ~0, max_time = 0, average_time = 0;
 void setup()
 {
     Serial.begin(9600);
+    pixyViSy.setGoalSig(GOAL_SIG);
+    pixyViSy.setBallSig(BALL_SIG);
+    pixyViSy.setMinGoalArea(MIN_GOAL_AREA);
+    /* You can also set another custom preferences (e.g. setBallSize) */
 }
+
 void loop()
 {
     time = (uint32_t)micros();


### PR DESCRIPTION
* Some parameters we can set defaultly by rcj rules and some only when user
  wants to use them
* Use 'area' rather than 'size' for result of width*height

Signed-off-by: vargac <simon.varga123@gmail.com>